### PR TITLE
Fix stuck crafting results, support default push mode + Advanced AE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ eclipse
 run
 runs
 run-data
+*.log
 
 repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2
+- Fix: crafting results no longer get stuck in the machine — the pending result was dropped as soon as the crafting service reported 0, which happened before the crafting CPU had registered the job (and again on world load), stranding the output
+- Fix: import card now works on pattern provider blocks left in the default "push to all sides" mode (previously it only worked when a single push direction was set, e.g. the cable part form)
+- Add: Advanced AE pattern provider support (regular + small, block + part)
+
+## 1.0.1
 - Allow card to be sneak-clicked into pattern providers
 - Add compatibility with me soul card mod
 - Add PT_BR localization (@PrincessStellar)

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,10 @@ dependencies {
     compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
     runtimeOnly "dev.emi:emi-neoforge:${emi_version}"
 
+    // Advanced AE, compile-time only (soft dependency). Its provider is a full reimplementation,
+    // so the compat mixins need to reference its classes at compile time.
+    compileOnly files("${projectDir}/../_refs/mods/AdvancedAE-1.6.11-1.21.1.jar")
+
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ mod_name=ae2helpers
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT License
 # The mod version. See https://semver.org/
-mod_version=1.0.1
+mod_version=1.0.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/rearth/ae2helpers/client/AdvProviderUpgradePanel.java
+++ b/src/main/java/rearth/ae2helpers/client/AdvProviderUpgradePanel.java
@@ -1,0 +1,62 @@
+package rearth.ae2helpers.client;
+
+import appeng.api.upgrades.Upgrades;
+import appeng.client.gui.style.ScreenStyle;
+import appeng.client.gui.style.WidgetStyle;
+import appeng.client.gui.WidgetContainer;
+import appeng.client.gui.widgets.UpgradesPanel;
+import appeng.core.localization.GuiText;
+import appeng.menu.AEBaseMenu;
+import net.minecraft.network.chat.Component;
+import net.neoforged.fml.ModList;
+import net.pedroksl.advanced_ae.common.logic.AdvPatternProviderLogicHost;
+import rearth.ae2helpers.ae2helpers;
+import rearth.ae2helpers.mixin.importcard.ScreenStyleAccessor;
+import rearth.ae2helpers.util.IPatternProviderUpgradeHost;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Shared by the (regular + small) Advanced AE pattern provider screen mixins to add the import card panel.
+public final class AdvProviderUpgradePanel {
+
+    private AdvProviderUpgradePanel() {
+    }
+
+    public static void install(ScreenStyle style, WidgetContainer widgets, AEBaseMenu menu) {
+        var existingStyle = style.getWidget("upgrades");
+
+        if (style instanceof ScreenStyleAccessor accessor) {
+            WidgetStyle upgradeStyle = existingStyle;
+            if (ModList.get().isLoaded("appflux") || ModList.get().isLoaded("mesoulcard")) {
+                upgradeStyle = new WidgetStyle();
+                upgradeStyle.setLeft(existingStyle.getLeft());
+                upgradeStyle.setRight(existingStyle.getRight());
+                upgradeStyle.setTop(existingStyle.getTop() + existingStyle.getHeight() + 32);
+                upgradeStyle.setHeight(existingStyle.getHeight());
+                upgradeStyle.setWidth(existingStyle.getWidth());
+                upgradeStyle.setHideEdge(existingStyle.isHideEdge());
+            }
+
+            accessor.ae2helpers$getWidgets().put("importupgrades", upgradeStyle);
+        }
+
+        widgets.add("importupgrades", new UpgradesPanel(
+          menu.getSlots(ae2helpers.IMPORT_UPGRADE),
+          () -> ae2helpers$getCompatibleUpgrades(menu)
+        ));
+    }
+
+    private static List<Component> ae2helpers$getCompatibleUpgrades(AEBaseMenu menu) {
+        var list = new ArrayList<Component>();
+        list.add(GuiText.CompatibleUpgrades.text());
+
+        if (menu.getTarget() instanceof AdvPatternProviderLogicHost host
+              && host.getLogic() instanceof IPatternProviderUpgradeHost upgradeHost) {
+            var inventory = upgradeHost.ae2helpers$getUpgradeInventory();
+            list.addAll(Upgrades.getTooltipLinesForMachine(inventory.getUpgradableItem()));
+        }
+
+        return list;
+    }
+}

--- a/src/main/java/rearth/ae2helpers/mixin/importcard/aae/AdvPatternProviderImportMixin.java
+++ b/src/main/java/rearth/ae2helpers/mixin/importcard/aae/AdvPatternProviderImportMixin.java
@@ -1,4 +1,4 @@
-package rearth.ae2helpers.mixin.importcard;
+package rearth.ae2helpers.mixin.importcard.aae;
 
 import appeng.api.behaviors.StackImportStrategy;
 import appeng.api.crafting.IPatternDetails;
@@ -9,8 +9,6 @@ import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.upgrades.IUpgradeInventory;
 import appeng.api.upgrades.UpgradeInventories;
-import appeng.helpers.patternprovider.PatternProviderLogic;
-import appeng.helpers.patternprovider.PatternProviderLogicHost;
 import appeng.parts.automation.StackWorldBehaviors;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -19,6 +17,8 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
+import net.pedroksl.advanced_ae.common.logic.AdvPatternProviderLogic;
+import net.pedroksl.advanced_ae.common.logic.AdvPatternProviderLogicHost;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -37,47 +37,49 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(PatternProviderLogic.class)
-public abstract class PatternProviderImportMixin implements IPatternProviderUpgradeHost {
-    
+// Advanced AE reimplements the pattern provider with its own classes, so it needs its own copy
+// of the import logic. Kept in sync with rearth.ae2helpers.mixin.importcard.PatternProviderImportMixin.
+@Mixin(AdvPatternProviderLogic.class)
+public abstract class AdvPatternProviderImportMixin implements IPatternProviderUpgradeHost {
+
     @Shadow @Final private IManagedGridNode mainNode;
     @Shadow @Final private IActionSource actionSource;
-    @Shadow @Final private PatternProviderLogicHost host;
+    @Shadow @Final private AdvPatternProviderLogicHost host;
     @Shadow public abstract void saveChanges();
-    
+
     // cached import strategy per provider target side
     @Unique private final Map<Direction, StackImportStrategy> ae2helpers$importStrategies = new EnumMap<>(Direction.class);
 
     // used to detect config changes (invalidates all cached strategies)
     @Unique private Direction ae2helpers$lastUsedConfigDirection;
-    
+
     @Unique private IUpgradeInventory ae2helpers$upgradeSlots = UpgradeInventories.empty();
     @Unique private final Map<AEKey, Long> ae2helpers$expectedResults = new HashMap<>();
 
     // Keys the crafting service has actually tracked (getRequestedAmount > 0) at least once.
     // Only then is a later "0" a trustworthy "craft finished" signal.
     @Unique private final java.util.Set<AEKey> ae2helpers$confirmedCrafts = new java.util.HashSet<>();
-    
+
     @Unique private int ae2helpers$cyclesSinceLastCheck = 0;
     @Unique private float ae2helpers$currentCycleDelay = 1f;
     @Unique private static final int AEHELPERS$MAX_CYCLE_DELAY = 10;
-    
-    @Inject(method = "<init>(Lappeng/api/networking/IManagedGridNode;Lappeng/helpers/patternprovider/PatternProviderLogicHost;I)V",at = @At("TAIL"))
-    private void ae2extras$initUpgrade(IManagedGridNode mainNode, PatternProviderLogicHost host, int patternInventorySize, CallbackInfo ci) {
+
+    @Inject(method = "<init>(Lappeng/api/networking/IManagedGridNode;Lnet/pedroksl/advanced_ae/common/logic/AdvPatternProviderLogicHost;I)V", at = @At("TAIL"))
+    private void ae2helpers$initUpgrade(IManagedGridNode mainNode, AdvPatternProviderLogicHost host, int patternInventorySize, CallbackInfo ci) {
         this.ae2helpers$upgradeSlots = UpgradeInventories.forMachine(ae2helpers.RESULT_IMPORT_CARD, 1, this::saveChanges);
     }
-    
+
     @Inject(method = "pushPattern", at = @At("RETURN"))
     private void ae2helpers$onPushPattern(IPatternDetails patternDetails, KeyCounter[] inputHolder, CallbackInfoReturnable<Boolean> cir) {
         if (cir.getReturnValue()) {
             if (!ae2helpers$hasImportCard()) return;
-            
+
             for (var output : patternDetails.getOutputs()) {
                 if (output != null) {
                     ae2helpers$expectedResults.merge(output.what(), output.amount(), Long::sum);
                 }
             }
-            
+
             ae2helpers$currentCycleDelay = 1;
             ae2helpers$cyclesSinceLastCheck = 0;
             this.saveChanges();
@@ -85,15 +87,15 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
             this.mainNode.ifPresent((grid, node) -> grid.getTickManager().alertDevice(node));
         }
     }
-    
+
     @Unique
     private void ae2helpers$syncWithCraftingService() {
         var grid = this.mainNode.getGrid();
         if (grid == null) return;
-        
+
         var craftingService = grid.getCraftingService();
         if (craftingService == null) return;
-        
+
         // forget confirmations for keys we no longer expect
         ae2helpers$confirmedCrafts.retainAll(ae2helpers$expectedResults.keySet());
 
@@ -123,11 +125,11 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
 
         if (changed) this.saveChanges();
     }
-    
+
     @Inject(method = "doWork", at = @At("RETURN"), cancellable = true)
     private void ae2helpers$onDoWork(CallbackInfoReturnable<Boolean> cir) {
         if (!this.mainNode.isActive()) return;
-        
+
         if (!ae2helpers$hasImportCard()) {
             if (!ae2helpers$expectedResults.isEmpty()) {
                 ae2helpers$expectedResults.clear();
@@ -135,46 +137,40 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
             }
             return;
         }
-        
+
         var config = ae2helpers$getConfig();
-        
-        // If we are in "Result Only" mode AND have no expectations, we sleep.
-        // If "Result Only" is FALSE (Import Everything), we must run even if map is empty.
+
         if (config.resultsOnly() && ae2helpers$expectedResults.isEmpty()) return;
-        
+
         ae2helpers$cyclesSinceLastCheck++;
-        
+
         if (ae2helpers$cyclesSinceLastCheck >= (int) ae2helpers$currentCycleDelay) {
             ae2helpers$cyclesSinceLastCheck = 0;
-            
+
             var didWork = ae2helpers$doImportWork(config);
-            
+
             if (didWork) {
                 ae2helpers$currentCycleDelay = 1;
                 cir.setReturnValue(true);
             } else {
                 ae2helpers$currentCycleDelay = Math.min(AEHELPERS$MAX_CYCLE_DELAY, ae2helpers$currentCycleDelay * 1.15f);
             }
-            
-            // Sync only if there is data AND config allows it
+
             if (!ae2helpers$expectedResults.isEmpty() && config.syncToGrid()) {
                 ae2helpers$syncWithCraftingService();
             }
         }
     }
-    
+
     @Inject(method = "hasWorkToDo", at = @At("RETURN"), cancellable = true)
     private void ae2helpers$hasWorkToDo(CallbackInfoReturnable<Boolean> cir) {
-        // If AE2 thinks it's asleep, check if we need to wake up
         if (!cir.getReturnValue() && ae2helpers$hasImportCard()) {
             var config = ae2helpers$getConfig();
-            // Wake up if: "Import All" mode is ON, OR we have specific results waiting
             if (!config.resultsOnly() || !ae2helpers$expectedResults.isEmpty()) {
                 cir.setReturnValue(true);
             }
         }
     }
-    
     @Unique
     private boolean ae2helpers$doImportWork(ImportCardConfig config) {
         var targets = this.host.getTargets();
@@ -188,13 +184,11 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
 
         var overriddenSide = config.overriddenDirection();
 
-        // Config direction changed -> drop all cached strategies so they get rebuilt with the new face.
         if (this.ae2helpers$lastUsedConfigDirection != overriddenSide) {
             this.ae2helpers$importStrategies.clear();
             this.ae2helpers$lastUsedConfigDirection = overriddenSide;
         }
 
-        // Drop cached strategies for sides that are no longer valid targets (e.g. push direction changed).
         this.ae2helpers$importStrategies.keySet().removeIf(side -> !targets.contains(side));
 
         var context = new PatternProviderImportContext(
@@ -202,11 +196,9 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
           this.mainNode.getGrid().getEnergyService(),
           this.actionSource,
           this.ae2helpers$expectedResults,
-          config.resultsOnly() // Pass the mode
+          config.resultsOnly()
         );
 
-        // Import from every side the provider pushes to. Only the side(s) with a real machine will
-        // yield anything; in "results only" mode the context filter additionally restricts to expected results.
         for (var side : targets) {
             var strategy = this.ae2helpers$importStrategies.computeIfAbsent(side, s -> {
                 var targetFace = overriddenSide != null ? overriddenSide : s.getOpposite();
@@ -220,18 +212,17 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
 
         var importedMap = context.getImportedItems();
         if (!importedMap.isEmpty()) {
-            // always track results/expectations in case config is changed
             if (!ae2helpers$expectedResults.isEmpty()) {
                 var changed = false;
                 var it = ae2helpers$expectedResults.entrySet().iterator();
-                
+
                 while (it.hasNext()) {
                     var entry = it.next();
                     var key = entry.getKey();
                     var expected = entry.getValue();
-                    
+
                     var actuallyImported = importedMap.getOrDefault(key, 0L);
-                    
+
                     if (actuallyImported > 0) {
                         var remaining = expected - actuallyImported;
                         if (remaining <= 0) {
@@ -242,30 +233,30 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
                         changed = true;
                     }
                 }
-                
+
                 if (changed) {
                     this.saveChanges();
                 }
             }
             return true;
         }
-        
+
         return false;
     }
-    
+
     @Unique
     private ImportCardConfig ae2helpers$getConfig() {
         if (!ae2helpers$hasImportCard()) return ImportCardConfig.DEFAULT;
         var stack = ae2helpers$upgradeSlots.getStackInSlot(0);
         return stack.getOrDefault(ae2helpers.IMPORT_CARD_CONFIG.get(), ImportCardConfig.DEFAULT);
     }
-    
+
     @Unique
     private boolean ae2helpers$hasImportCard() {
         return !ae2helpers$upgradeSlots.getStackInSlot(0).isEmpty()
                  && ae2helpers$upgradeSlots.getStackInSlot(0).is(ae2helpers.RESULT_IMPORT_CARD.get());
     }
-    
+
     @Inject(method = "clearContent", at = @At("HEAD"))
     private void ae2helpers$onClearContent(CallbackInfo ci) {
         this.ae2helpers$importStrategies.clear();
@@ -274,16 +265,16 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
         this.ae2helpers$confirmedCrafts.clear();
         this.ae2helpers$upgradeSlots.clear();
     }
-    
+
     @Inject(method = "addDrops", at = @At("TAIL"))
-    private void ae2extras$dropUpgrade(List<ItemStack> drops, CallbackInfo ci) {
+    private void ae2helpers$dropUpgrade(List<ItemStack> drops, CallbackInfo ci) {
         for (var slot : this.ae2helpers$upgradeSlots) {
             if (!slot.isEmpty()) {
                 drops.add(slot);
             }
         }
     }
-    
+
     @Inject(method = "writeToNBT", at = @At("TAIL"))
     private void ae2helpers$writeToNBT(CompoundTag tag, HolderLookup.Provider registries, CallbackInfo ci) {
         if (!ae2helpers$expectedResults.isEmpty()) {
@@ -295,7 +286,7 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
         }
         ae2helpers$upgradeSlots.writeToNBT(tag, "ae2helperupgrades", registries);
     }
-    
+
     @Inject(method = "readFromNBT", at = @At("TAIL"))
     private void ae2helpers$readFromNBT(CompoundTag tag, HolderLookup.Provider registries, CallbackInfo ci) {
         ae2helpers$expectedResults.clear();
@@ -310,7 +301,7 @@ public abstract class PatternProviderImportMixin implements IPatternProviderUpgr
         }
         ae2helpers$upgradeSlots.readFromNBT(tag, "ae2helperupgrades", registries);
     }
-    
+
     @Override
     public IUpgradeInventory ae2helpers$getUpgradeInventory() {
         return ae2helpers$upgradeSlots;

--- a/src/main/java/rearth/ae2helpers/mixin/importcard/aae/AdvPatternProviderMenuMixin.java
+++ b/src/main/java/rearth/ae2helpers/mixin/importcard/aae/AdvPatternProviderMenuMixin.java
@@ -1,0 +1,49 @@
+package rearth.ae2helpers.mixin.importcard.aae;
+
+import appeng.api.upgrades.IUpgradeInventory;
+import appeng.menu.AEBaseMenu;
+import appeng.menu.slot.RestrictedInputSlot;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.MenuType;
+import net.pedroksl.advanced_ae.common.logic.AdvPatternProviderLogic;
+import net.pedroksl.advanced_ae.common.logic.AdvPatternProviderLogicHost;
+import net.pedroksl.advanced_ae.gui.advpatternprovider.AdvPatternProviderMenu;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import rearth.ae2helpers.ae2helpers;
+import rearth.ae2helpers.util.IPatternProviderUpgradeHost;
+
+// SmallAdvPatternProviderMenu extends this menu, so injecting the shared constructor covers both.
+@Mixin(AdvPatternProviderMenu.class)
+public abstract class AdvPatternProviderMenuMixin extends AEBaseMenu {
+
+    @Shadow @Final protected AdvPatternProviderLogic logic;
+
+    public AdvPatternProviderMenuMixin(MenuType<?> menuType, int id, Inventory playerInventory, Object host) {
+        super(menuType, id, playerInventory, host);
+    }
+
+    @Inject(
+      method = "<init>(Lnet/minecraft/world/inventory/MenuType;ILnet/minecraft/world/entity/player/Inventory;Lnet/pedroksl/advanced_ae/common/logic/AdvPatternProviderLogicHost;)V",
+      at = @At("TAIL")
+    )
+    private void ae2helpers$initUpgrades(MenuType<?> menuType, int id, Inventory playerInventory, AdvPatternProviderLogicHost host, CallbackInfo ci) {
+        if (this.logic instanceof IPatternProviderUpgradeHost upgradeHost) {
+            ae2helpers$createUpgradeSlots(upgradeHost.ae2helpers$getUpgradeInventory());
+        }
+    }
+
+    @Unique
+    protected final void ae2helpers$createUpgradeSlots(IUpgradeInventory upgrades) {
+        for (int i = 0; i < upgrades.size(); i++) {
+            var slot = new RestrictedInputSlot(RestrictedInputSlot.PlacableItemType.UPGRADES, upgrades, i);
+            slot.setNotDraggable();
+            this.addSlot(slot, ae2helpers.IMPORT_UPGRADE);
+        }
+    }
+}

--- a/src/main/java/rearth/ae2helpers/mixin/importcard/aae/AdvPatternProviderScreenMixin.java
+++ b/src/main/java/rearth/ae2helpers/mixin/importcard/aae/AdvPatternProviderScreenMixin.java
@@ -1,0 +1,26 @@
+package rearth.ae2helpers.mixin.importcard.aae;
+
+import appeng.client.gui.AEBaseScreen;
+import appeng.client.gui.style.ScreenStyle;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.pedroksl.advanced_ae.client.gui.AdvPatternProviderScreen;
+import net.pedroksl.advanced_ae.gui.advpatternprovider.AdvPatternProviderMenu;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import rearth.ae2helpers.client.AdvProviderUpgradePanel;
+
+@Mixin(AdvPatternProviderScreen.class)
+public abstract class AdvPatternProviderScreenMixin extends AEBaseScreen<AdvPatternProviderMenu> {
+
+    public AdvPatternProviderScreenMixin(AdvPatternProviderMenu menu, Inventory playerInventory, Component title, ScreenStyle style) {
+        super(menu, playerInventory, title, style);
+    }
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void ae2helpers$initUpgradePanel(AdvPatternProviderMenu menu, Inventory playerInventory, Component title, ScreenStyle style, CallbackInfo ci) {
+        AdvProviderUpgradePanel.install(style, this.widgets, menu);
+    }
+}

--- a/src/main/java/rearth/ae2helpers/mixin/importcard/aae/SmallAdvPatternProviderScreenMixin.java
+++ b/src/main/java/rearth/ae2helpers/mixin/importcard/aae/SmallAdvPatternProviderScreenMixin.java
@@ -1,0 +1,26 @@
+package rearth.ae2helpers.mixin.importcard.aae;
+
+import appeng.client.gui.AEBaseScreen;
+import appeng.client.gui.style.ScreenStyle;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.pedroksl.advanced_ae.client.gui.SmallAdvPatternProviderScreen;
+import net.pedroksl.advanced_ae.gui.advpatternprovider.SmallAdvPatternProviderMenu;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import rearth.ae2helpers.client.AdvProviderUpgradePanel;
+
+@Mixin(SmallAdvPatternProviderScreen.class)
+public abstract class SmallAdvPatternProviderScreenMixin extends AEBaseScreen<SmallAdvPatternProviderMenu> {
+
+    public SmallAdvPatternProviderScreenMixin(SmallAdvPatternProviderMenu menu, Inventory playerInventory, Component title, ScreenStyle style) {
+        super(menu, playerInventory, title, style);
+    }
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void ae2helpers$initUpgradePanel(SmallAdvPatternProviderMenu menu, Inventory playerInventory, Component title, ScreenStyle style, CallbackInfo ci) {
+        AdvProviderUpgradePanel.install(style, this.widgets, menu);
+    }
+}

--- a/src/main/java/rearth/ae2helpers/util/AdvancedAeCardCompat.java
+++ b/src/main/java/rearth/ae2helpers/util/AdvancedAeCardCompat.java
@@ -1,0 +1,30 @@
+package rearth.ae2helpers.util;
+
+import appeng.api.upgrades.IUpgradeInventory;
+import appeng.blockentity.networking.CableBusBlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.Vec3;
+import net.pedroksl.advanced_ae.common.entities.AdvPatternProviderEntity;
+import net.pedroksl.advanced_ae.common.parts.AdvPatternProviderPart;
+import org.jetbrains.annotations.Nullable;
+
+// Only referenced when the "advanced_ae" mod is loaded (guarded in ImportCardItem), so it is safe to
+// hard-reference Advanced AE classes here.
+public final class AdvancedAeCardCompat {
+
+    private AdvancedAeCardCompat() {
+    }
+
+    @Nullable
+    public static IUpgradeInventory getUpgradeInventory(BlockEntity te, Vec3 clickLocation) {
+        if (te instanceof AdvPatternProviderEntity provider && provider.getLogic() instanceof IPatternProviderUpgradeHost upgradeHost) {
+            return upgradeHost.ae2helpers$getUpgradeInventory();
+        }
+        if (te instanceof CableBusBlockEntity be
+              && be.selectPartWorld(clickLocation).part instanceof AdvPatternProviderPart part
+              && part.getLogic() instanceof IPatternProviderUpgradeHost upgradeHost) {
+            return upgradeHost.ae2helpers$getUpgradeInventory();
+        }
+        return null;
+    }
+}

--- a/src/main/java/rearth/ae2helpers/util/ImportCardItem.java
+++ b/src/main/java/rearth/ae2helpers/util/ImportCardItem.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.neoforged.fml.ModList;
 import org.jetbrains.annotations.NotNull;
 import rearth.ae2helpers.ae2helpers;
 import rearth.ae2helpers.client.ImportCardClientHelper;
@@ -57,6 +58,8 @@ public class ImportCardItem extends UpgradeCardItem {
                 upgrades = upgradeHost.ae2helpers$getUpgradeInventory();
             } else if (te instanceof PatternProviderBlockEntity provider && provider.getLogic() instanceof IPatternProviderUpgradeHost upgradeHost) {
                 upgrades = upgradeHost.ae2helpers$getUpgradeInventory();
+            } else if (te != null && ModList.get().isLoaded("advanced_ae")) {
+                upgrades = AdvancedAeCardCompat.getUpgradeInventory(te, context.getClickLocation());
             }
             
             if (upgrades != null) {

--- a/src/main/resources/ae2helpers.aae.mixins.json
+++ b/src/main/resources/ae2helpers.aae.mixins.json
@@ -1,0 +1,19 @@
+{
+  "required": true,
+  "package": "rearth.ae2helpers.mixin.importcard.aae",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "AdvPatternProviderImportMixin",
+    "AdvPatternProviderMenuMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
+  },
+  "client": [
+    "AdvPatternProviderScreenMixin",
+    "SmallAdvPatternProviderScreenMixin"
+  ]
+}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -47,6 +47,11 @@ Small mod that enables automatically putting requested crafting items in the gri
 [[mixins]]
 config="${mod_id}.mixins.json"
 
+# Advanced AE compat mixins. Skipped automatically when Advanced AE is not installed
+# (their target classes are never loaded), so no hard dependency is created.
+[[mixins]]
+config="${mod_id}.aae.mixins.json"
+
 # The [[accessTransformers]] block allows you to declare where your AT file is.
 # If this block is omitted, a fallback attempt will be made to load an AT from META-INF/accesstransformer.cfg
 #[[accessTransformers]]


### PR DESCRIPTION
- Fix: crafting results are no longer stranded in the machine. The pending result was dropped as soon as the crafting service reported 0, which happens before the crafting CPU registers the job (and again on world load). Now an expectation is only cleared once the crafting service has actually tracked it (confirmed-craft tracking).
- Fix: import now works on pattern provider blocks left in the default "push to all sides" mode. getTargets() returns all 6 sides there, which the old size()==1 guard rejected; import from every target side instead.
- Add: Advanced AE pattern provider support (block + part, regular + small) via its own mixin set; soft dependency, dormant when the mod is absent.
- Bump to 1.0.2